### PR TITLE
Execution timeouts

### DIFF
--- a/src/Sandbox.lua
+++ b/src/Sandbox.lua
@@ -309,7 +309,7 @@ function Sandbox:ClearTimer(): number
 end
 
 -- Adds CPU time (NOTE: Will trigger timeout errors in the caller)
-function Sandbox:AddCPUTime(cpuTime)
+function Sandbox:AddCPUTime(cpuTime: number)
 	local cpuInfo = self.CPUInfo
 	cpuInfo.CPU += cpuTime
 	cpuInfo.LifetimeCPU += cpuTime

--- a/src/Sandbox.lua
+++ b/src/Sandbox.lua
@@ -41,7 +41,8 @@ local function closeThread(thread: thread)
 	end
 end
 
-local fullyWeak = {__mode = "kv"; __metatable="The metatable is locked."}
+local fullyWeak = table.freeze({__mode = "kv"; __metatable="The metatable is locked."})
+local weakKeys = table.freeze({__mode = "k"; __metatable="The metatable is locked."})
 
 -- Sandbox
 local Sandbox = {}

--- a/tests/compatibility/yielding.spec.lua
+++ b/tests/compatibility/yielding.spec.lua
@@ -1,0 +1,31 @@
+--# selene: allow(undefined_variable)
+
+return function()
+	local ReplicatedStorage = game:GetService("ReplicatedStorage")
+	local Packages = ReplicatedStorage.Packages
+
+	local Chlorine = require(Packages.Chlorine)
+
+	local Sandbox = Chlorine.Sandbox
+	local Environment = Chlorine.Environment
+
+	local sandbox = Sandbox.new()
+	local environment = Environment.new():boundTo(sandbox):withFenv({task = task})
+
+	local it = it;
+	local expect = expect;
+
+	describe("sandbox", function()
+		local success = false
+		it("should be able to run and yield", function()
+			expect(sandbox:Spawn(environment:applyTo(function()
+				task.wait(1)
+				success = true
+			end))).to.never.be.equal(false)
+		end)
+		task.wait(1)
+		it("should run all the way through", function()
+			expect(success).to.be.ok()
+		end)
+	end)
+end

--- a/tests/rules/timeout.spec.lua
+++ b/tests/rules/timeout.spec.lua
@@ -1,0 +1,50 @@
+--# selene: allow(undefined_variable)
+
+return function()
+	local ReplicatedStorage = game:GetService("ReplicatedStorage")
+	local Packages = ReplicatedStorage.Packages
+
+	local Chlorine = require(Packages.Chlorine)
+
+	local Sandbox = Chlorine.Sandbox
+	local Environment = Chlorine.Environment
+
+	local sandbox = Sandbox.new()
+	local environment = Environment.new():boundTo(sandbox):withFenv({coroutine = coroutine; task = task; print = print;})
+
+	local it = it;
+	local expect = expect;
+
+	describe("sandbox", function()
+		it("should not be able to exceed the timeout", function()
+			sandbox:SetTimeout(0.1)
+			expect(sandbox:Spawn(environment:applyTo(function()
+				while true do
+					coroutine.running()
+				end
+			end))).to.be.equal(false)
+		end)
+		it("should work if there are other threads", function()
+			sandbox = sandbox:renew()
+			environment = Environment.new():boundTo(sandbox):withFenv({coroutine = coroutine; task = task; print = print;})
+
+			sandbox:SetTimeout(0.1)
+			expect(sandbox:Spawn(environment:applyTo(function()
+				while true do
+					task.wait()
+				end
+			end))).to.never.be.equal(false)
+			expect(sandbox:Spawn(environment:applyTo(function()
+				assert(coroutine.resume(coroutine.create(function()
+					while true do
+						function doWait()
+							task.wait()
+						end
+						task.spawn(doWait)
+						task.spawn(task.wait)
+					end
+				end)))
+			end))).to.be.equal(false)
+		end)
+	end)
+end

--- a/wally.toml
+++ b/wally.toml
@@ -1,7 +1,7 @@
 [package]
 name = "hexcede/chlorine"
 description = "A luau sandbox designed to work with Matter."
-version = "0.0.1"
+version = "0.0.2"
 license = "MIT"
 authors = ["Hexcede"]
 registry = "https://github.com/UpliftGames/wally-index"


### PR DESCRIPTION
- Adds tracking of CPU time spent by lua code running in the sandbox (not including yields & engine calls)
- Adds custom script timeouts (The roblox timeout will still apply, could add some throttling to prevent that later down the line)
- Add `Sandbox:SetTimeout(timeout)` method which allows setting an execution timeout in seconds.
- Add `Sandbox:GetCPUTime()` which returns the time the sandbox has spent running without yielding.
- Add `Sandbox:GetTimer(thread)` which returns the amount of time on the thread's timer (`0` if there is not an active timer)

- Add `Sandbox:ClearTimer()` which forgets the current CPU usage (primarily for internal use)
- Add `Sandbox:StartTimer(thread)` which starts counting CPU time in a thread (primarily for internal use)
- Add `Sandbox:StopTimer(thread)` which stops counting CPU time in a thread (primarily for internal use)